### PR TITLE
Refactor Neovim config to Emacs

### DIFF
--- a/emacs/evil-config.el
+++ b/emacs/evil-config.el
@@ -1,0 +1,68 @@
+(use-package general
+  :demand t)
+
+(use-package evil
+  :demand t
+  :init
+  (setq evil-want-integration t)
+  (setq evil-want-keybinding nil)
+  (setq evil-want-C-u-scroll t)
+  (setq evil-want-C-i-jump t)
+  (setq evil-undo-system 'undo-redo)
+  :config
+  (evil-mode 1)
+  (define-key evil-insert-state-map (kbd "C-g") 'evil-normal-state)
+
+  ;; Use visual line motions even outside of visual-line-mode buffers
+  (evil-global-set-key 'motion "j" 'evil-next-visual-line)
+  (evil-global-set-key 'motion "k" 'evil-previous-visual-line)
+
+  (evil-set-initial-state 'messages-buffer-mode 'normal)
+  (evil-set-initial-state 'dashboard-mode 'normal))
+
+(use-package evil-collection
+  :after evil
+  :config
+  (evil-collection-init))
+
+;; Wait for evil and general to be ready before defining keys
+(elpaca-wait)
+
+(general-create-definer my/leader-keys
+  :keymaps '(normal insert visual emacs)
+  :prefix "SPC"
+  :global-prefix "C-SPC")
+
+(my/leader-keys
+  "SPC" '(execute-extended-command :which-key "execute command")
+  "q"  '(:ignore t :which-key "quit/session")
+  "qq" '(save-buffers-kill-terminal :which-key "quit emacs")
+
+  "f"  '(:ignore t :which-key "file/find")
+  "ff" '(find-file :which-key "find file")
+  "fs" '(save-buffer :which-key "save file")
+
+  "w"  '(:ignore t :which-key "windows")
+  "wq" '(delete-window :which-key "quit window")
+  "wd" '(delete-window :which-key "delete window")
+  "wo" '(delete-other-windows :which-key "close other windows")
+  "ws" '(split-window-below :which-key "horizontal split")
+  "wv" '(split-window-right :which-key "vertical split")
+  "wh" '(evil-window-left :which-key "window left")
+  "wj" '(evil-window-down :which-key "window down")
+  "wk" '(evil-window-up :which-key "window up")
+  "wl" '(evil-window-right :which-key "window right")
+
+  "b"  '(:ignore t :which-key "buffers")
+  "bb" '(switch-to-buffer :which-key "switch buffer")
+  "bd" '(kill-current-buffer :which-key "delete buffer")
+  "br" '(revert-buffer :which-key "reload buffer")
+  "b[" '(previous-buffer :which-key "previous buffer")
+  "b]" '(next-buffer :which-key "next buffer")
+
+  "<leader>" '(mode-line-other-buffer :which-key "alternate buffer"))
+
+;; Map C-s to save in all states
+(general-define-key
+ :keymaps '(normal insert visual emacs)
+ "C-s" 'save-buffer)

--- a/emacs/git-file-config.el
+++ b/emacs/git-file-config.el
@@ -1,0 +1,29 @@
+(use-package magit
+  :commands magit-status
+  :config
+  (my/leader-keys
+    "g"   '(:ignore t :which-key "git")
+    "gg"  '(magit-status :which-key "magit status")
+    "gb"  '(magit-branch-checkout :which-key "git branch")
+    "gl"  '(magit-log-current :which-key "git log")
+    "gd"  '(magit-diff-unstaged :which-key "git diff")))
+
+(use-package dirvish
+  :init
+  (dirvish-override-dired-mode)
+  :config
+  (setq dirvish-mode-line-format
+        '(:left (path) :right (free-space)))
+  (setq dirvish-attributes
+        '(vc-state subtree-state git-msg file-size))
+  (my/leader-keys
+    "e"   '(:ignore t :which-key "file explorer")
+    "ee"  '(dirvish :which-key "open dirvish")
+    "ec"  '(dirvish-side :which-key "dirvish side")))
+
+(use-package vterm
+  :commands vterm
+  :config
+  (setq vterm-max-scrollback 10000)
+  (my/leader-keys
+    "st"  '(vterm :which-key "terminal")))

--- a/emacs/init.el
+++ b/emacs/init.el
@@ -1,0 +1,78 @@
+;;; init.el --- Emacs configuration -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; This is a simple, maintainable, and modern Emacs configuration
+;; that mirrors a Neovim setup.
+
+;;; Code:
+
+;; Bootstrap Elpaca
+(defvar elpaca-installer-version 0.9)
+(defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
+(defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
+(defvar elpaca-repos-directory (expand-file-name "repos/" elpaca-directory))
+(defvar elpaca-order '(elpaca :repo "https://github.com/progfolio/elpaca.git"
+                              :ref nil :depth 1
+                              :files (:exclude "extensions")
+                              :build (:not elpaca--activate-package)))
+(let* ((repo  (expand-file-name "elpaca/" elpaca-repos-directory))
+       (build (expand-file-name "elpaca/" elpaca-builds-directory))
+       (order (cdr elpaca-order))
+       (default-directory repo))
+  (add-to-list 'load-path (if (file-exists-p build) build repo))
+  (unless (file-exists-p repo)
+    (make-directory repo t)
+    (when (< emacs-major-version 28) (require 'subr-x))
+    (condition-case-unless-debug err
+        (if-let* ((buffer (shell-command-to-string (format "git clone %s %s" (plist-get order :repo) repo))))
+            (message "%s" buffer)
+          (error "Could not clone elpaca %s" err))
+      (error (delete-directory repo t) (signal (car err) (cdr err)))))
+  (require 'elpaca-client)
+  (elpaca-wait)
+  (elpaca elpaca-order (elpaca--activate-package)))
+
+;; Install use-package support for Elpaca
+(elpaca elpaca-use-package
+  (elpaca-use-package-mode))
+(setq use-package-always-ensure t)
+(elpaca-wait)
+
+;; Basic UI settings
+(setq inhibit-startup-message t)
+(scroll-bar-mode -1)
+(tool-bar-mode -1)
+(tooltip-mode -1)
+(set-fringe-mode 10)
+(menu-bar-mode -1)
+
+(setq visible-bell t)
+
+(column-number-mode)
+(global-display-line-numbers-mode t)
+
+;; Disable line numbers for some modes
+(dolist (mode '(org-mode-hook
+                term-mode-hook
+                shell-mode-hook
+                treemacs-mode-hook
+                eshell-mode-hook))
+  (add-hook mode (lambda () (display-line-numbers-mode 0))))
+
+;; Indentation
+(setq-default tab-width 4)
+(setq-default indent-tabs-mode nil)
+
+;; Encoding
+(set-language-environment "UTF-8")
+(set-default-coding-systems 'utf-8)
+
+;; Load configurations
+(load (expand-file-name "evil-config.el" user-emacs-directory))
+(load (expand-file-name "ui-config.el" user-emacs-directory))
+(load (expand-file-name "lsp-config.el" user-emacs-directory))
+(load (expand-file-name "git-file-config.el" user-emacs-directory))
+(load (expand-file-name "theme-config.el" user-emacs-directory))
+
+(provide 'init)
+;;; init.el ends here

--- a/emacs/lsp-config.el
+++ b/emacs/lsp-config.el
@@ -1,0 +1,35 @@
+;; Completion
+(use-package corfu
+  :custom
+  (corfu-auto t)
+  (corfu-auto-delay 0)
+  (corfu-auto-prefix 1)
+  :init
+  (global-corfu-mode))
+
+(use-package yasnippet
+  :init
+  (yas-global-mode 1))
+
+;; Treesitter
+(setq treesit-font-lock-level 4)
+
+;; LSP
+(use-package eglot
+  :ensure nil ; Built-in
+  :hook ((python-mode . eglot-ensure)
+         (nix-mode . eglot-ensure)
+         (js-mode . eglot-ensure)
+         (lua-mode . eglot-ensure))
+  :config
+  (my/leader-keys
+    "c"   '(:ignore t :which-key "code")
+    "ca"  '(eglot-code-actions :which-key "code actions")
+    "cr"  '(eglot-rename :which-key "rename")
+    "cf"  '(eglot-format-buffer :which-key "format buffer")
+    "cd"  '(eldoc :which-key "documentation")))
+
+(use-package nix-mode
+  :mode "\\.nix\\'")
+
+(use-package lua-mode)

--- a/emacs/theme-config.el
+++ b/emacs/theme-config.el
@@ -1,0 +1,17 @@
+(use-package everforest-theme
+  :config
+  (load-theme 'everforest-hard-dark t))
+
+(use-package nerd-icons
+  :if (display-graphic-p))
+
+(use-package doom-modeline
+  :after nerd-icons
+  :init (doom-modeline-mode 1)
+  :custom
+  ((doom-modeline-height 25)
+   (doom-modeline-icon t)
+   (doom-modeline-major-mode-icon t)))
+
+(use-package rainbow-delimiters
+  :hook (prog-mode . rainbow-delimiters-mode))

--- a/emacs/ui-config.el
+++ b/emacs/ui-config.el
@@ -1,0 +1,78 @@
+(use-package vertico
+  :init
+  (vertico-mode))
+
+(use-package savehist
+  :init
+  (savehist-mode))
+
+(use-package marginalia
+  :after vertico
+  :init
+  (marginalia-mode))
+
+(use-package orderless
+  :custom
+  (completion-styles '(orderless basic))
+  (completion-category-overrides '((file (styles partial-completion)))))
+
+(use-package consult
+  :bind (;; C-c bindings (mode-specific-map)
+         ("C-c h" . consult-history)
+         ("C-c m" . consult-mode-command)
+         ("C-c k" . consult-kmacro)
+         ;; C-x bindings (ctl-x-map)
+         ("C-x M-:" . consult-complex-command)     ;; orig. repeat-complex-command
+         ("C-x b" . consult-buffer)                ;; orig. switch-to-buffer
+         ("C-x 4 b" . consult-buffer-other-window) ;; orig. switch-to-buffer-other-window
+         ("C-x 5 b" . consult-buffer-other-frame)  ;; orig. switch-to-buffer-other-frame
+         ("C-x r b" . consult-bookmark)            ;; orig. switch-to-bookmark
+         ("C-x p b" . consult-project-buffer)      ;; orig. project-switch-to-buffer
+         ;; Other custom bindings
+         ("M-y" . consult-yank-pop)                ;; orig. yank-pop
+         ;; M-g bindings (goto-map)
+         ("M-g e" . consult-compile-error)
+         ("M-g f" . consult-flymake)               ;; Alternative: consult-flycheck
+         ("M-g g" . consult-goto-line)             ;; orig. goto-line
+         ("M-g M-g" . consult-goto-line)           ;; orig. goto-line
+         ("M-g o" . consult-outline)               ;; Alternative: consult-org-heading
+         ("M-g m" . consult-mark)
+         ("M-g k" . consult-global-mark)
+         ("M-g i" . consult-imenu)
+         ("M-g I" . consult-imenu-multi)
+         ;; M-s bindings (search-map)
+         ("M-s d" . consult-find)
+         ("M-s D" . consult-locate)
+         ("M-s g" . consult-grep)
+         ("M-s G" . consult-git-grep)
+         ("M-s r" . consult-ripgrep)
+         ("M-s l" . consult-line)
+         ("M-s L" . consult-line-multi)
+         ("M-s m" . consult-multi-occur)
+         ("M-s k" . consult-keep-lines)
+         ("M-s u" . consult-focus-lines)
+         ;; Isearch integration
+         ("M-s e" . consult-isearch-history)
+         :map isearch-mode-map
+         ("M-e" . consult-isearch-history)         ;; orig. isearch-edit-string
+         ("M-s e" . consult-isearch-history)       ;; orig. isearch-edit-string
+         ("M-s l" . consult-line)                  ;; needed by consult-line to detect isearch
+         ("M-s L" . consult-line-multi)            ;; needed by consult-line to detect isearch
+         ;; Minibuffer history
+         :map minibuffer-local-map
+         ("M-s" . consult-history)                 ;; orig. next-matching-history-element
+         ("M-r" . consult-history))                ;; orig. previous-matching-history-element
+  :config
+  (my/leader-keys
+    "/"   '(consult-ripgrep :which-key "grep (root dir)")
+    "ff"  '(consult-find :which-key "find files")
+    "fr"  '(consult-recent-file :which-key "recent files")
+    "sd"  '(consult-flymake :which-key "diagnostics")
+    "sk"  '(describe-bindings :which-key "keymaps")
+    "ss"  '(consult-line :which-key "search line")))
+
+(use-package which-key
+  :init
+  (which-key-mode)
+  :config
+  (setq which-key-idle-delay 0.3))

--- a/nixos/home-modules/emacs.nix
+++ b/nixos/home-modules/emacs.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  const,
+  pkgs,
+  guardRole,
+  ...
+}:
+
+guardRole "dev" {
+  home.sessionVariables = {
+    EDITOR = "emacsclient -t";
+    VISUAL = "emacsclient -c -a emacs";
+  };
+
+  xdg.configFile."emacs" = {
+    source = config.lib.file.mkOutOfStoreSymlink "${const.dotfilesDir}/emacs";
+    recursive = true;
+  };
+
+  programs.emacs = {
+    enable = true;
+    package = pkgs.emacs-pgtk; # Better for Wayland/GNOME
+    extraPackages = epkgs: with epkgs; [
+      vterm
+    ];
+  };
+
+  services.emacs = {
+    enable = true;
+    client.enable = true;
+  };
+
+  home.packages = with pkgs; [
+    # Runtime dependencies for Emacs
+    ripgrep
+    fd
+    git
+    gnumake
+    cmake
+    libtool
+
+    # LSP Servers
+    nixd
+    pyright
+    nodePackages.typescript-language-server
+    lua-language-server
+  ];
+}


### PR DESCRIPTION
This PR migrates the user's Neovim configuration to a modular, simple, and maintainable Emacs setup. 

Key features:
1. **Evil-mode & General.el**: Preserves the Vim-style editing and Space-leader keybindings from the Neovim config.
2. **Minad UI Stack**: Uses Vertico, Consult, Marginalia, and Orderless for a modern, picker-driven navigation experience similar to Snacks.nvim.
3. **LSP & Completion**: Implements Eglot (built-in LSP) and Corfu (completion-at-point) with language servers managed via Nix.
4. **Git & Files**: Swaps Lazygit for Magit and Mini.files for Dirvish.
5. **NixOS Integration**: Adds a new Home Manager module `emacs.nix` that handles the installation of `emacs-pgtk`, runtime dependencies, and configuration symlinking.
6. **Robust Bootstrap**: Uses the Elpaca package manager to ensure the configuration is portable and handles its own dependency installation.

---
*PR created automatically by Jules for task [3610567309062414256](https://jules.google.com/task/3610567309062414256) started by @icristianhernandez*